### PR TITLE
feature: replace favicon with public link

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="https://raw.githubusercontent.com/Portus-NFT-Marketplace/Portus-Frontend/main/public/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta


### PR DESCRIPTION
ตอน deploy มันหาไฟล์​ favicon.ico ไม่เจอ ไม่แน่ใจว่าปกติเขาแก้กันยังไง แต่วิธีที่แก้ตามที่เปิด PR ไปก็น่าจะเวิคขอลองดูก่อน

ตัวอย่าง  error

<img width="1192" alt="image" src="https://user-images.githubusercontent.com/59832457/227704128-5dc0755f-0067-4d64-8a24-49dfee091d53.png">
